### PR TITLE
WIP: try to get a build working on the public github runners again (and maybe add build cache)

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,6 +17,7 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt
+      - uses: Swatinem/rust-cache@v1
       - run: cargo fmt --all -- --check
   clippy_test:
     runs-on: ubuntu-latest
@@ -27,4 +28,5 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+      - uses: Swatinem/rust-cache@v1
       - run: cargo clippy --tests --all-targets --all-features -- --D warnings

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,7 +2,7 @@ name: cargo-fmt
 
 on:
   pull_request:
-    branches: [main]
+    branches: ["*"]
     paths: ["**/*.rs"]
 
   workflow_dispatch:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -3,7 +3,7 @@ name: cargo-fmt
 on:
   pull_request:
     branches: ["*"]
-    paths: ["**/*.rs"]
+    paths: ["**/*.rs", "**/*.yml"]
 
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths: ["**/*.rs", "**/Cargo.toml"]
   pull_request:
-    branches: [main]
+    branches: ["*"]
     paths: ["**/*.rs", "**/Cargo.toml"]
 
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,5 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - run: cargo test --all-features -- --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cargo_test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: getsynth/checkout@v2
       - uses: getsynth/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: cargo-test
 on:
   push:
     branches: [main]
-    paths: ["**/*.rs", "**/Cargo.toml"]
+    paths: ["**/*.rs", "**/Cargo.toml", "**/*.yml"]
   pull_request:
     branches: ["*"]
-    paths: ["**/*.rs", "**/Cargo.toml"]
+    paths: ["**/*.rs", "**/Cargo.toml", "**/*.yml"]
 
   workflow_dispatch:
 


### PR DESCRIPTION
WIP

I think that it would be valuable to get the tests running using the public runners, even if they are slow.

It is highly likely that the cache action won't help us, because managing the docker layer cache in github actions is a royal pain. At FutureNHS, we ended up just building the binaries on the runner instance, and copying them into the docker image.

- [ ] put an API key into github secrets, and copy it into dirs::config_dir()/shuttle/config.toml somehow before running tests.
- [ ] uncover the next error
- [ ] ...
- [ ] profit?